### PR TITLE
Added grammar for `a=connection:new`

### DIFF
--- a/lib/src/grammar.dart
+++ b/lib/src/grammar.dart
@@ -171,6 +171,12 @@ var grammar = {
       'format': 'setup:%s'
     },
     {
+      // a=connection:new
+      'name': 'connectionType',
+      'reg': r'^connection:(new|existing)',
+      'format': 'connection:%s'
+    },
+    {
       // a=mid:1
       'name': 'mid',
       'reg': r'^mid:([^\s]*)',


### PR DESCRIPTION
Asterisk includes this in the SDP and it caused a `trying to add null key` message to be output before.

sdp-transform.js has a similar grammar rule.

The Asterisk test already worked before and still works. Output before:

```
00:00 +19 -1: test/sdp_parse_test.dart: asterisk
trying to add null key
got session info
```

Output now:

```
00:00 +19 -1: test/sdp_parse_test.dart: asterisk
got session info
```